### PR TITLE
patch bug

### DIFF
--- a/third_party/patches/opencensus-go-exporter-stackdriver/opencensus-stackdriver-interval.patch
+++ b/third_party/patches/opencensus-go-exporter-stackdriver/opencensus-stackdriver-interval.patch
@@ -46,3 +46,4 @@ index 902b776..edebc93 100644
 +	mpt.Interval = toValidTimeIntervalpb(*startTime, pt.Time)
  	return mpt, nil
  }
+ 


### PR DESCRIPTION
closes #https://github.com/bazelbuild/reclient/issues/24

It looks like windows is picky about a newline at the end of the file