### PR TITLE
Enable clangscandeps in github build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
   bazel-build:
     strategy:
       matrix:
-        includescanner: ["goma"] #, "clangscandeps"] # TODO: Add clangscandeps builds
+        includescanner: ["goma", "clangscandeps"] # TODO: Add clangscandeps builds
         os: ["ubuntu-20.04", "macos-13", "windows-2019"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This is a WIP pr to enable building clangscandeps variant of artifacts.tar