### PR TITLE
Fix `-instance` doc in cmd-line-flags.md

### DIFF
--- a/docs/cmd-line-flags.md
+++ b/docs/cmd-line-flags.md
@@ -15,9 +15,8 @@ does not need to be set.
 
 **`-instance (string)`**
 
-The instance to target when calling the remote execution service via gRPC. For
-Remote Build Execution, the format is
-`projects/_project-id_/instances/_instance-name_`.
+The instance ID to target when calling remote execution via gRPC
+(e.g., projects/$PROJECT/instances/default_instance for Google RBE).
 
 **`-use_application_default_credentials (bool) (from remote-apis-sdks)`**
 


### PR DESCRIPTION
This brings it in line with [remote-apis-sdks](https://github.com/bazelbuild/remote-apis-sdks/blob/108231926e9cfc51732b364b5e93f3253d2f8191/go/pkg/flags/flags.go#L60C2-L60C28).