### PR TITLE
fixup! RBE build execution issue

### DIFF
--- a/cmd/rewrapper/main.go
+++ b/cmd/rewrapper/main.go
@@ -194,6 +194,11 @@ func main() {
 	if err != nil {
 		log.Exitf("Failed to compute working directory path relative to the exec root: %v", err)
 	}
+	// REAPI uses an empty working_directory to mean "run at the input root".
+	// Some backends reject "." even though it represents the same location.
+	if cOpts.WorkDir == "." {
+		cOpts.WorkDir = ""
+	}
 	if strings.HasPrefix(cOpts.WorkDir, "..") {
 		log.Exitf("Current working directory (%q) is not under the exec root (%q), relative working dir = %q", wd, cOpts.ExecRoot, cOpts.WorkDir)
 	}

--- a/internal/pkg/reproxy/action.go
+++ b/internal/pkg/reproxy/action.go
@@ -242,7 +242,7 @@ func depth(path string) int {
 // This path is normalized so that all separators are os.PathSeparator
 func toRemoteWorkingDir(workingDir string) string {
 	if workingDir == "" || workingDir == "." {
-		return workingDir
+		return ""
 	}
 	dirDepth := depth(filepath.Clean(workingDir))
 	elem := make([]string, dirDepth)


### PR DESCRIPTION
This commit fixes the **BuildBuddy** remote build execution issue.

Remote execution was failing before this change. After applying this patch and using the new binary files, builds started executing successfully again.

The fix was tested with an AOSP build.
