### PR TITLE
logdump: add -output_format flag with json support

### DIFF
--- a/cmd/logdump/main.go
+++ b/cmd/logdump/main.go
@@ -1,18 +1,3 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// logdump binary reads reproxy log files and dumps them in a single file that is queryable by gqui.
 package main
 
 import (
@@ -24,6 +9,7 @@ import (
 	"github.com/bazelbuild/reclient/internal/pkg/rbeflag"
 	"github.com/bazelbuild/reclient/internal/pkg/version"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	lpb "github.com/bazelbuild/reclient/api/log"
@@ -33,10 +19,11 @@ import (
 )
 
 var (
-	proxyLogDir []string
-	logFormat   = flag.String("log_format", "text", "Format of proxy log. Currently only text is supported.")
-	logPath     = flag.String("log_path", "", "DEPRECATED. Use proxy_log_dir instead. If provided, the path to a log file of all executed records. The format is e.g. text://full/file/path.")
-	outputDir   = flag.String("output_dir", "/tmp/", "The location to which stats should be written.")
+	proxyLogDir  []string
+	logFormat    = flag.String("log_format", "text", "Format of proxy log. Currently only text is supported.")
+	logPath      = flag.String("log_path", "", "DEPRECATED. Use proxy_log_dir instead. If provided, the path to a log file of all executed records. The format is e.g. text://full/file/path.")
+	outputDir    = flag.String("output_dir", "/tmp/", "The location to which stats should be written.")
+	outputFormat = flag.String("output_format", "pb", "The output format. Can be 'pb' suitable for reproducing issues or 'json' for plain text reading.")
 )
 
 func main() {
@@ -54,6 +41,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Bad log format: %v", err)
 	}
+	if *outputFormat != "pb" && *outputFormat != "json" {
+		log.Fatalf("Bad output format (must be 'pb' or 'json'): %s", *outputFormat)
+	}
 
 	var recs []*lpb.LogRecord
 	if len(proxyLogDir) != 0 {
@@ -68,12 +58,26 @@ func main() {
 		}
 	}
 	dump := &lpb.LogDump{Records: recs}
-	out, err := proto.Marshal(dump)
+
+	var out []byte
+	var outFile string
+	if *outputFormat == "json" {
+		opts := protojson.MarshalOptions{
+			UseProtoNames:   true,
+			EmitUnpopulated: true,
+		}
+		out, err = opts.Marshal(dump)
+		outFile = "reproxy_log.json"
+	} else {
+		out, err = proto.Marshal(dump)
+		outFile = "reproxy_log.pb"
+	}
 	if err != nil {
 		log.Fatalf("Failed to encode log records: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(*outputDir, "reproxy_log.pb"), out, 0644); err != nil {
-		log.Fatalf("Failed to write log pb file: %v", err)
+
+	if err := os.WriteFile(filepath.Join(*outputDir, outFile), out, 0644); err != nil {
+		log.Fatalf("Failed to write log output file: %v", err)
 	}
 	log.Infof("Log dumped successfully.")
 }

--- a/cmd/logdump/main.go
+++ b/cmd/logdump/main.go
@@ -1,3 +1,18 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// logdump binary reads reproxy log files and dumps them in a single file that is queryable by gqui.
 package main
 
 import (


### PR DESCRIPTION
This makes it easier for consumers to process the output without needing to import protobuf bindings.